### PR TITLE
Fix fallback of _get_video_info

### DIFF
--- a/resources/lib/KodiMonitor.py
+++ b/resources/lib/KodiMonitor.py
@@ -231,8 +231,8 @@ class KodiMonitor(xbmc.Monitor):
         except KeyError:
             self.log('Guessing video info (fallback={})'.format(fallback_data),
                      xbmc.LOGWARNING)
-            return (self._guess_episode(info, fallback_data) or
-                    self._guess_movie(info, fallback_data))
+            return (_guess_episode(info, fallback_data) or
+                    _guess_movie(info, fallback_data))
 
     @log
     def _update_item_details(self, properties):


### PR DESCRIPTION
The code which handle KeyError exception in _get_video_info try to call functions define outside the class using `self.x` instead of gust `x`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?

